### PR TITLE
feat: remove artifact types and add media types

### DIFF
--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -30,7 +30,7 @@ const (
 	// referenced by the manifest.
 	MediaTypeModelLayerGzip = "application/vnd.cnai.model.layer.v1.tar+gzip"
 
-	// MediaTypeModelDoc specifies the media type for a model documentation, includes documentation files like `README.md`, `LICENSE`, etc.
+	// MediaTypeModelDoc specifies the media type for model documentation, including documentation files like `README.md`, `LICENSE`, etc.
 	MediaTypeModelDoc = "application/vnd.cnai.model.doc.v1.tar"
 
 	// MediaTypeModelCode specifies the media type for a model code, includes code artifacts like scripts, code files etc.

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -17,16 +17,25 @@
 package v1
 
 const (
-	// ArtifactTypeModelManifest specifies the media type for a model manifest.
-	ArtifactTypeModelManifest = "application/vnd.cnai.model.manifest.v1+json"
+	// MediaTypeModelManifest specifies the media type for a model manifest.
+	MediaTypeModelManifest = "application/vnd.cnai.model.manifest.v1+json"
 
-	// ArtifactTypeModelConfig specifies the media type for a model configuration.
-	ArtifactTypeModelConfig = "application/vnd.cnai.model.config.v1+json"
+	// MediaTypeModelConfig specifies the media type for a model configuration.
+	MediaTypeModelConfig = "application/vnd.cnai.model.config.v1+json"
 
-	// ArtifactTypeModelLayer is the media type used for layers referenced by the manifest.
-	ArtifactTypeModelLayer = "application/vnd.cnai.model.layer.v1.tar"
+	// MediaTypeModelLayer is the media type used for layers referenced by the manifest.
+	MediaTypeModelLayer = "application/vnd.cnai.model.layer.v1.tar"
 
-	// ArtifactTypeModelLayerGzip is the media type used for gzipped layers
+	// MediaTypeModelLayerGzip is the media type used for gzipped layers
 	// referenced by the manifest.
-	ArtifactTypeModelLayerGzip = "application/vnd.cnai.model.layer.v1.tar+gzip"
+	MediaTypeModelLayerGzip = "application/vnd.cnai.model.layer.v1.tar+gzip"
+
+	// MediaTypeModelDoc specifies the media type for a model documentation, includes documentation files like `README.md`, `LICENSE`, etc.
+	MediaTypeModelDoc = "application/vnd.cnai.model.doc.v1.tar"
+
+	// MediaTypeModelCode specifies the media type for a model code, includes code artifacts like scripts, code files etc.
+	MediaTypeModelCode = "application/vnd.cnai.model.code.v1.tar"
+
+	// MediaTypeModelDataset specifies the media type for a model dataset, includes datasets that may be needed for the lifecycle of AI/ML models.
+	MediaTypeModelDataset = "application/vnd.cnai.model.dataset.v1.tar"
 )

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -36,6 +36,6 @@ const (
 	// MediaTypeModelCode specifies the media type for model code, including code artifacts like scripts, code files etc.
 	MediaTypeModelCode = "application/vnd.cnai.model.code.v1.tar"
 
-	// MediaTypeModelDataset specifies the media type for a model dataset, includes datasets that may be needed for the lifecycle of AI/ML models.
+	// MediaTypeModelDataset specifies the media type for model datasets, including datasets that may be needed throughout the lifecycle of AI/ML models.
 	MediaTypeModelDataset = "application/vnd.cnai.model.dataset.v1.tar"
 )

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -33,7 +33,7 @@ const (
 	// MediaTypeModelDoc specifies the media type for model documentation, including documentation files like `README.md`, `LICENSE`, etc.
 	MediaTypeModelDoc = "application/vnd.cnai.model.doc.v1.tar"
 
-	// MediaTypeModelCode specifies the media type for a model code, includes code artifacts like scripts, code files etc.
+	// MediaTypeModelCode specifies the media type for model code, including code artifacts like scripts, code files etc.
 	MediaTypeModelCode = "application/vnd.cnai.model.code.v1.tar"
 
 	// MediaTypeModelDataset specifies the media type for a model dataset, includes datasets that may be needed for the lifecycle of AI/ML models.


### PR DESCRIPTION
This pull request includes changes to the `specs-go/v1/mediatype.go` file to update and expand the media type constants for model-related artifacts. The most important changes include renaming existing constants for clarity and adding new constants for additional media types.

Renaming for clarity:

* Changed `ArtifactTypeModelManifest` to `MediaTypeModelManifest` to better reflect its purpose.
* Changed `ArtifactTypeModelConfig` to `MediaTypeModelConfig` to better reflect its purpose.
* Changed `ArtifactTypeModelLayer` to `MediaTypeModelLayer` to better reflect its purpose.
* Changed `ArtifactTypeModelLayerGzip` to `MediaTypeModelLayerGzip` to better reflect its purpose.

Adding new media types:

* Added `MediaTypeModelDoc` for model documentation files like `README.md` and `LICENSE`.
* Added `MediaTypeModelCode` for code artifacts like scripts and code files.
* Added `MediaTypeModelDataset` for datasets needed for the lifecycle of AI/ML models.