### PR TITLE
spec: remove InfoURL in ModelDescriptor

### DIFF
--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -64,9 +64,6 @@ type ModelDescriptor struct {
 	// The model name, such as llama3-8b-instruct, gpt2-xl, qwen2-vl-72b-instruct, etc.
 	Name string `json:"name,omitempty"`
 
-	// The URL to find more information on the model
-	InfoURL string `json:"infoURL,omitempty"`
-
 	// The URL to get documentation on the model
 	DocURL string `json:"docURL,omitempty"`
 


### PR DESCRIPTION
The filed InfoURL is no longer necessary, and seems confusing.

See the [discussion](https://cloud-native.slack.com/archives/C07T0V480LF/p1739257048027399?thread_ts=1739251984.440139&cid=C07T0V480LF).

Signed-off-by: Zhao Chen <zhaochen.zju@gmail.com>