### PR TITLE
docs: remove useless annotations

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -33,6 +33,4 @@ This property contains arbitrary metadata, and SHOULD follow the rules of [OCI i
 
 ### Layer Annotation Keys
 
-- **`org.cnai.model.readme`**: Specifies the layer is a README.md file (boolean), such as `true` or `false`.
-- **`org.cnai.model.license`**: Specifies the layer is a LICENSE file (boolean), such as `true` or `false`.
 - **`org.cnai.model.filepath`**: Specifies the file path of the layer (string).


### PR DESCRIPTION
This pull request includes a minor update to the `docs/annotations.md` file. The change involves removing outdated annotation keys related to README and LICENSE files.

Documentation updates:

* [`docs/annotations.md`](diffhunk://#diff-d210c46f7c35fae8f95ec8111564cc357a038b0ec63128f7707f31087a6f7115L36-L37): Removed the `org.cnai.model.readme` and `org.cnai.model.license` annotation keys as they are no longer relevant.