### PR TITLE
feat: optimize definition of the model spec

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -4,33 +4,6 @@ This property contains arbitrary metadata, and SHOULD follow the rules of [OCI i
 
 ## Pre-defined Annotation Keys
 
-### Manifest Annotation Keys
-
-#### Model-common Annotation Keys
-
-- **`org.cnai.model.created`**: Date and time on which the model was built, conforming to [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6).
-- **`org.cnai.model.authors`**: Contact details of the people or organization responsible for the model (freeform string).
-- **`org.cnai.model.url`**: URL to find more information on the model (string).
-- **`org.cnai.model.documentation`**: URL to get documentation on the model (string).
-- **`org.cnai.model.source`**: URL to get source code for building the model (string).
-- **`org.cnai.model.version`**: Version of the model.
-- **`org.cnai.model.revision`**: Source control revision identifier for the model.
-- **`org.cnai.model.vendor`**: Name of the distributing entity, organization or individual.
-- **`org.cnai.model.licenses`**: License(s) under which contained software is distributed as an [SPDX License Expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/).
-- **`org.cnai.model.ref.name`**: Name of the reference for a target (string).
-- **`org.cnai.model.title`**: Human-readable title of the model (string).
-- **`org.cnai.model.description`**: Human-readable description of the software packaged in the model (string).
-
-#### Model-specific Annotation Keys
-
-- **`org.cnai.model.architecture`**: Model architecture (string), such as `transformer`, `cnn`, `rnn`, etc.
-- **`org.cnai.model.family`**: Model family (string), such as `llama3`, `gpt2`, `qwen2`, etc.
-- **`org.cnai.model.name`**: Model name (string), such as `llama3-8b-instruct`, `gpt2-xl`, `qwen2-vl-72b-instruct`, etc.
-- **`org.cnai.model.format`**: Model format (string), such as `onnx`, `tensorflow`, `pytorch`, etc.
-- **`org.cnai.model.param.size`**: Number of parameters in the model (integer).
-- **`org.cnai.model.precision`**: Model precision (string), such as `bf16`, `fp16`, `int8`, etc.
-- **`org.cnai.model.quantization`**: Model quantization (string), such as `awq`, `gptq`, etc.
-
 ### Layer Annotation Keys
 
 - **`org.cnai.model.filepath`**: Specifies the file path of the layer (string).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6,9 +6,9 @@ The goal of this specification is to outline a blueprint and enable the creation
 
 ## Use Cases
 
-* An OCI Registry can store and manage AI/ML model artifacts, making model versions, metadata, and parameters both retrievable and easily displayed.
-* A Data Scientist can package models together with their metadata (e.g., format, precision) and upload them to a registry, facilitating collaboration with MLOps Engineers while streamlining the deployment process to efficiently deliver models into production.
-* A model serving/deployment platform can read model metadata (e.g., format, precision) from a registry to understand the AI/ML model details, identify the required server runtime
+- An OCI Registry can store and manage AI/ML model artifacts, making model versions, metadata, and parameters both retrievable and easily displayed.
+- A Data Scientist can package models together with their metadata (e.g., format, precision) and upload them to a registry, facilitating collaboration with MLOps Engineers while streamlining the deployment process to efficiently deliver models into production.
+- A model serving/deployment platform can read model metadata (e.g., format, precision) from a registry to understand the AI/ML model details, identify the required server runtime
   (as well as startup parameters, necessary resources, etc.), and serve the model in Kubernetes by [mounting it directly as a volume source](https://kubernetes.io/blog/2024/08/16/kubernetes-1-31-image-volume-source/)
   without needing to pre-download it in an init-container or bundle it within the server runtime container.
 
@@ -20,34 +20,43 @@ At a high level, the Model Format Specification is based on the [OCI Image Forma
 
 The image manifest of model artifacts follows the [OCI Image Manifest Specification][image-manifest] and adheres to the [artifacts guidance](https://github.com/opencontainers/image-spec/blob/main/artifacts-guidance.md).
 
-* **`mediaType`** *string*
+- **`mediaType`** _string_
+
+  This REQUIRED property MUST be `application/vnd.oci.image.manifest.v1+json`, refer to the [Guidelines for Artifact Usage](https://github.com/opencontainers/image-spec/blob/main/artifacts-guidance.md).
+
+- **`artifactType`** _string_
 
   This REQUIRED property MUST be `application/vnd.cnai.model.manifest.v1+json`.
 
-* **`layers`** *array of objects*
+- **`layers`** _array of objects_
 
-  * **`mediaType`** *string*
+  - **`mediaType`** _string_
 
-       This is a REQUIRED property. Implementations MUST support at least the following media types:
+    This is a REQUIRED property. Implementations MUST support at least the following media types:
 
-    * `application/vnd.cnai.model.layer.v1.tar`: The layer is a [tar archive][tar-archive] that contains the model weight file. If the model has multiple weight files, they SHOULD be packaged into separate layers.
+    - `application/vnd.cnai.model.weight.v1.tar`: The layer is a [tar archive][tar-archive] that contains the model weight file. If the model has multiple weight files, they SHOULD be packaged into separate layers.
 
-    * `application/vnd.cnai.model.doc.v1.tar`: The layer is a [tar archive][tar-archive] that includes documentation files like `README.md`, `LICENSE`, etc.
+      Also, implementations SHOULD support the following media types:
 
-    * `application/vnd.cnai.model.code.v1.tar`: The layer is a [tar archive][tar-archive] that includes code artifacts like scripts, code files etc.
+    - `application/vnd.cnai.model.weight.config.v1.tar`: The layer is a [tar archive][tar-archive] that includes config of the model weights like `tokenizer.json`, `config.json`, etc.
 
-    * `application/vnd.cnai.model.dataset.v1.tar`: The layer is a [tar archive][tar-archive] that includes datasets that may be needed for the lifecycle of AI/ML models.
+    - `application/vnd.cnai.model.doc.v1.tar`: The layer is a [tar archive][tar-archive] that includes documentation files like `README.md`, `LICENSE`, etc.
 
-    * **`annotations`** *string-string map*
+    - `application/vnd.cnai.model.code.v1.tar`: The layer is a [tar archive][tar-archive] that includes code artifacts like scripts, code files etc.
 
-      This OPTIONAL property contains arbitrary attributes for the layer. For metadata specific to models, implementations SHOULD use the predefined annotation keys as outlined in the [Layer Annotation Keys](./annotations.md#layer-annotation-keys).
+    - `application/vnd.cnai.model.dataset.v1.tar`: The layer is a [tar archive][tar-archive] that includes datasets that may be needed for the lifecycle of AI/ML models.
+
+  - **`annotations`** _string-string map_
+
+    This OPTIONAL property contains arbitrary attributes for the layer. For metadata specific to models, implementations SHOULD use the predefined annotation keys as outlined in the [Layer Annotation Keys](./annotations.md#layer-annotation-keys).
 
 ### Example Image Manifest For Model Artifacts
 
 ```JSON
 {
     "schemaVersion": 2,
-    "mediaType": "application/vnd.cnai.model.manifest.v1+json",
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "artifactType": "application/vnd.cnai.model.manifest.v1+json",
     "config": {
         "mediaType": "application/vnd.cnai.model.config.v1+json",
         "digest": "sha256:d5815835051dd97d800a03f641ed8162877920e734d3d705b698912602b8c763",
@@ -55,15 +64,20 @@ The image manifest of model artifacts follows the [OCI Image Manifest Specificat
     },
     "layers": [
         {
-            "mediaType": "application/vnd.cnai.model.layer.v1.tar",
+            "mediaType": "application/vnd.cnai.model.weight.v1.tar",
             "digest": "sha256:3f907c1a03bf20f20355fe449e18ff3f9de2e49570ffb536f1a32f20c7179808",
             "size": 30327160
         },
         {
-            "mediaType": "application/vnd.cnai.model.layer.v1.tar",
+            "mediaType": "application/vnd.cnai.model.weight.v1.tar",
             "digest": "sha256:6d923539c5c208de77146335584252c0b1b81e35c122dd696fe6e04ed03d7411",
             "size": 5018536960
         },
+        {
+            "mediaType": "application/vnd.cnai.model.weight.config.v1.tar",
+            "digest": "sha256:a5378e569c625f7643952fcab30c74f2a84ece52335c292e630f740ac4694146",
+            "size": 106
+        }
         {
             "mediaType": "application/vnd.cnai.model.doc.v1.tar",
             "digest": "sha256:5e236ec37438b02c01c83d134203a646cb354766ac294e533a308dd8caa3a11e",
@@ -81,30 +95,30 @@ This section describes how to serialize AI/ML artifacts into a blob called a lay
 
 ### `+gzip` Media Types
 
-The `application/vnd.cnai.model.layer.v1.tar+gzip` represents an `application/vnd.cnai.model.layer.v1.tar` payload which has been compressed with [gzip][rfc1952_2]. The mediaTypes `application/vnd.cnai.model.doc.v1.tar+gzip`, `application/vnd.cnai.model.code.v1.tar+gzip`, `application/vnd.cnai.model.dataset.v1.tar+gzip` refer to the gzip compressed payloads of their corresponding type.
+The `application/vnd.cnai.model.weight.v1.tar+gzip` represents an `application/vnd.cnai.model.weight.v1.tar` payload which has been compressed with [gzip][rfc1952_2]. The mediaTypes `application/vnd.cnai.model.weight.config.v1.tar+gzip`, `application/vnd.cnai.model.doc.v1.tar+gzip`, `application/vnd.cnai.model.code.v1.tar+gzip`, `application/vnd.cnai.model.dataset.v1.tar+gzip` refer to the gzip compressed payloads of their corresponding type.
 
 ### `+zstd` Media Types
 
-The `application/vnd.cnai.model.layer.v1.tar+zstd` represents an `application/vnd.cnai.model.layer.v1.tar` payload which has been compressed with the [zstd][rfc8478] algorithm. The mediaTypes `application/vnd.cnai.model.doc.v1.tar+zstd`, `application/vnd.cnai.model.code.v1.tar+zstd`, `application/vnd.cnai.model.dataset.v1.tar+zstd` refer to the zstd compressed payloads of their corresponding type.
+The `application/vnd.cnai.model.weight.v1.tar+zstd` represents an `application/vnd.cnai.model.weight.v1.tar` payload which has been compressed with the [zstd][rfc8478] algorithm. The mediaTypes `application/vnd.cnai.model.weight.config.v1.tar+zstd`, `application/vnd.cnai.model.doc.v1.tar+zstd`, `application/vnd.cnai.model.code.v1.tar+zstd`, `application/vnd.cnai.model.dataset.v1.tar+zstd` refer to the zstd compressed payloads of their corresponding type.
 
 ### File Attributes
 
 Where supported, MUST include file attributes
 
-* Modification Time (`mtime`)
-* User ID (`uid`)
-  * User Name (`uname`) should be ignored on platforms that support User ID (`uid`)
-* Group ID (`gid`)
-  * Group Name (`gname`) should be ignored on platforms that support Group ID (`gid`)
-* Mode (`mode`)
+- Modification Time (`mtime`)
+- User ID (`uid`)
+  - User Name (`uname`) should be ignored on platforms that support User ID (`uid`)
+- Group ID (`gid`)
+  - Group Name (`gname`) should be ignored on platforms that support Group ID (`gid`)
+- Mode (`mode`)
 
 ### Reproducibility
 
 To ensure tar layers are packaged in a reproducible way, implementation SHOULD adhere to the following guidance:
 
-* If the archive includes multiple files, files should be added to the archive in lexicographical order.
-* File metadata (such as modification time, owner/group id) should be set to known, constant values rather than the current values on disk.
-* Platform/implementation specific metadata should be omitted from the archive.
+- If the archive includes multiple files, files should be added to the archive in lexicographical order.
+- File metadata (such as modification time, owner/group id) should be set to known, constant values rather than the current values on disk.
+- Platform/implementation specific metadata should be omitted from the archive.
 
 ## Workflow
 

--- a/specs-go/v1/annotations.go
+++ b/specs-go/v1/annotations.go
@@ -17,12 +17,6 @@
 package v1
 
 const (
-	// AnnotationConfig is the annotation key for the layer is a configuration file (boolean), such as `true` or `false`.
-	AnnotationConfig = "org.cnai.model.config"
-
-	// AnnotationModel is the annotation key for the layer is a model file (boolean), such as `true` or `false`.
-	AnnotationModel = "org.cnai.model.model"
-
 	// AnnotationFilepath is the annotation key for the file path of the layer.
 	AnnotationFilepath = "org.cnai.model.filepath"
 )

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -53,7 +53,7 @@ type ModelFS struct {
 // ModelDescriptor defines the general information of a model
 type ModelDescriptor struct {
 	// Date and time on which the model was built
-	CreateTime *time.Time `json:"createTime,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
 	// The contact details of the people or organization responsible for the model
 	Authors []string `json:"authors,omitempty"`

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -17,25 +17,56 @@
 package v1
 
 const (
-	// MediaTypeModelManifest specifies the media type for a model manifest.
-	MediaTypeModelManifest = "application/vnd.cnai.model.manifest.v1+json"
+	// ArtifactTypeModelManifest specifies the artifact type for a model manifest.
+	ArtifactTypeModelManifest = "application/vnd.cnai.model.manifest.v1+json"
+)
 
+const (
 	// MediaTypeModelConfig specifies the media type for a model configuration.
 	MediaTypeModelConfig = "application/vnd.cnai.model.config.v1+json"
 
-	// MediaTypeModelLayer is the media type used for layers referenced by the manifest.
-	MediaTypeModelLayer = "application/vnd.cnai.model.layer.v1.tar"
+	// MediaTypeModelWeight is the media type used for model weights.
+	MediaTypeModelWeight = "application/vnd.cnai.model.weight.v1.tar"
 
-	// MediaTypeModelLayerGzip is the media type used for gzipped layers
-	// referenced by the manifest.
-	MediaTypeModelLayerGzip = "application/vnd.cnai.model.layer.v1.tar+gzip"
+	// MediaTypeModelWeightGzip is the media type used for gzipped model weights.
+	MediaTypeModelWeightGzip = "application/vnd.cnai.model.weight.v1.tar+gzip"
+
+	// MediaTypeModelWeightZstd is the media type used for zstd compressed model weights.
+	MediaTypeModelWeightZstd = "application/vnd.cnai.model.weight.v1.tar+zstd"
+
+	// MediaTypeModelConfig specifies the media type for configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	MediaTypeModelWeightConfig = "application/vnd.cnai.model.weight.config.v1.tar"
+
+	// MediaTypeModelConfigGzip specifies the media type for gzipped configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	MediaTypeModelWeightConfigGzip = "application/vnd.cnai.model.weight.config.v1.tar+gzip"
+
+	// MediaTypeModelConfigZstd specifies the media type for zstd compressed configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	MediaTypeModelWeightConfigZstd = "application/vnd.cnai.model.weight.config.v1.tar+zstd"
 
 	// MediaTypeModelDoc specifies the media type for model documentation, including documentation files like `README.md`, `LICENSE`, etc.
 	MediaTypeModelDoc = "application/vnd.cnai.model.doc.v1.tar"
 
+	// MediaTypeModelDocGzip specifies the media type for gzipped model documentation, including documentation files like `README.md`, `LICENSE`, etc.
+	MediaTypeModelDocGzip = "application/vnd.cnai.model.doc.v1.tar+gzip"
+
+	// MediaTypeModelDocZstd specifies the media type for zstd compressed model documentation, including documentation files like `README.md`, `LICENSE`, etc.
+	MediaTypeModelDocZstd = "application/vnd.cnai.model.doc.v1.tar+zstd"
+
 	// MediaTypeModelCode specifies the media type for model code, including code artifacts like scripts, code files etc.
 	MediaTypeModelCode = "application/vnd.cnai.model.code.v1.tar"
 
+	// MediaTypeModelCodeGzip specifies the media type for gzipped model code, including code artifacts like scripts, code files etc.
+	MediaTypeModelCodeGzip = "application/vnd.cnai.model.code.v1.tar+gzip"
+
+	// MediaTypeModelCodeZstd specifies the media type for zstd compressed model code, including code artifacts like scripts, code files etc.
+	MediaTypeModelCodeZstd = "application/vnd.cnai.model.code.v1.tar+zstd"
+
 	// MediaTypeModelDataset specifies the media type for model datasets, including datasets that may be needed throughout the lifecycle of AI/ML models.
 	MediaTypeModelDataset = "application/vnd.cnai.model.dataset.v1.tar"
+
+	// MediaTypeModelDatasetGzip specifies the media type for gzipped model datasets, including datasets that may be needed throughout the lifecycle of AI/ML models.
+	MediaTypeModelDatasetGzip = "application/vnd.cnai.model.dataset.v1.tar+gzip"
+
+	// MediaTypeModelDatasetZstd specifies the media type for zstd compressed model datasets, including datasets that may be needed throughout the lifecycle of AI/ML models.
+	MediaTypeModelDatasetZstd = "application/vnd.cnai.model.dataset.v1.tar+zstd"
 )


### PR DESCRIPTION
This pull request includes significant updates to the documentation and codebase related to the handling of AI/ML model artifacts. The changes primarily focus on refining the specification, updating media types, and cleaning up deprecated annotations.

### Documentation Updates:
* Removed outdated model annotation keys from `docs/annotations.md` to streamline the documentation.
* Added new media types and clarified the use of `artifactType` and `mediaType` in `docs/spec.md`.
* Updated the `+gzip` and `+zstd` media types to include new entries for configuration files in `docs/spec.md`.

### Codebase Changes:
* Removed deprecated annotation keys from `specs-go/v1/annotations.go`.
* Renamed `CreateTime` to `CreatedAt` in `specs-go/v1/config.go` to standardize naming conventions.
* Updated media type constants and added new ones for configuration files in `specs-go/v1/mediatype.go`.