### PR TITLE
feat: add raw media type for model weights files

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -44,7 +44,9 @@ The image manifest of model artifacts follows the [OCI Image Manifest Specificat
 
     - `application/vnd.cnai.model.weight.v1.tar`: The layer is a [tar archive][tar-archive] that contains the model weight file. If the model has multiple weight files, they SHOULD be packaged into separate layers.
 
-      Also, implementations SHOULD support the following media types:
+    Also, implementations SHOULD support the following media types:
+
+    - `application/vnd.cnai.model.weight.v1.raw`: The layer is an unarchived, uncompressed model weights file. If the model weight files are large, implementations are RECOMMENDED to use this media type.
 
     - `application/vnd.cnai.model.weight.config.v1.tar`: The layer is a [tar archive][tar-archive] that includes config of the model weights like `tokenizer.json`, `config.json`, etc.
 

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -34,6 +34,9 @@ const (
 	// MediaTypeModelWeightZstd is the media type used for zstd compressed model weights.
 	MediaTypeModelWeightZstd = "application/vnd.cnai.model.weight.v1.tar+zstd"
 
+	// MediaTypeModelWeightRaw is the media type used for an unarchived, uncompressed model weights file.
+	MediaTypeModelWeightRaw = "application/vnd.cnai.model.weight.v1.raw"
+
 	// MediaTypeModelConfig specifies the media type for configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfig = "application/vnd.cnai.model.weight.config.v1.tar"
 


### PR DESCRIPTION
This commit introduces a `application/vnd.cnai.model.weight.v1.raw` media type. This will be beneficial for large language models, as the model weight files are giant, with individual files reaching up to 10GB and total files nearing 1TB: 

- Eliminates compression and archiving overhead, and accelerates build and start speed
- Reduces storage footprint during archiving and unarchiving

Similar PR in oci-spec: https://github.com/opencontainers/image-spec/pull/1197/files