### PR TITLE
chore: update golangci-lint configuration to remove unsupported properties

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 3m
+  timeout: 3m
   modules-download-mode: readonly
 
 linters-settings:
@@ -30,6 +30,8 @@ linters:
     - errcheck
 
 output:
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
+      path: stdout
   print-issued-lines: true
   print-linter-name: true


### PR DESCRIPTION
This pull request includes changes to the `.golangci.yml` configuration file to improve the linter settings and output format.

Configuration improvements:

* Changed the `deadline` parameter to `timeout` under the `run` section to better reflect the intended functionality. (`.golangci.yml`)

Output format enhancement:

* Modified the `output` section to support multiple formats and specified the output path for better clarity and control. (`.golangci.yml`)