### PR TITLE
feat: update parameter size field and documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -79,9 +79,9 @@ The following terms are used in this section:
 
     The format for the model, such as "onnx", "tensorflow", or "pytorch".
 
-  - **parameterSize** _integer_, OPTIONAL
+  - **paramSize** _string_, OPTIONAL
 
-    The total number of parameters of the model parameters.
+    The total number of parameters of the model parameters, such as "8b", "16b", "32b", etc.
 
   - **precision** _string_, OPTIONAL
 
@@ -109,34 +109,34 @@ Here is an example model artifact configuration JSON document:
 
 ```json
 {
-    "descriptor": {
-        "createdAt": "2025-01-01T00:00:00Z",
-        "authors": ["xyz@xyz.com"],
-        "vendor": "XYZ Corp.",
-        "family": "xyz3",
-        "name": "xyz-3-8B-Instruct",
-        "version": "3.1",
-        "title": "XYZ 3 8B Instruct",
-        "description": "xyz is a large language model.",
-        "docURL": "https://www.xyz.com/get-started/",
-        "sourceURL": "https://github.com/xyz/xyz3",
-        "revision": "1234567890",
-        "licenses": ["Apache-2.0"]
-    },
-    "config": {
-        "architecture": "transformer",
-        "format": "pytorch",
-        "parameterSize": "50000000000",
-        "precision": "fp16",
-        "quantization": "gptq"
-    },
-    "modelfs": {
-        "type": "layers",
-        "diff_ids": [
-            "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-        ]
-    }
+  "descriptor": {
+    "createdAt": "2025-01-01T00:00:00Z",
+    "authors": ["xyz@xyz.com"],
+    "vendor": "XYZ Corp.",
+    "family": "xyz3",
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1",
+    "title": "XYZ 3 8B Instruct",
+    "description": "xyz is a large language model.",
+    "docURL": "https://www.xyz.com/get-started/",
+    "sourceURL": "https://github.com/xyz/xyz3",
+    "revision": "1234567890",
+    "licenses": ["Apache-2.0"]
+  },
+  "config": {
+    "architecture": "transformer",
+    "format": "pytorch",
+    "paramSize": "8b",
+    "precision": "fp16",
+    "quantization": "gptq"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+      "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    ]
+  }
 }
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -85,7 +85,7 @@ The image manifest of model artifacts follows the [OCI Image Manifest Specificat
             "mediaType": "application/vnd.cnai.model.weight.config.v1.tar",
             "digest": "sha256:a5378e569c625f7643952fcab30c74f2a84ece52335c292e630f740ac4694146",
             "size": 106
-        }
+        },
         {
             "mediaType": "application/vnd.cnai.model.doc.v1.tar",
             "digest": "sha256:5e236ec37438b02c01c83d134203a646cb354766ac294e533a308dd8caa3a11e",

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -31,8 +31,8 @@ type ModelConfig struct {
 	// The model format, such as onnx, tensorflow, pytorch, etc.
 	Format string `json:"format,omitempty"`
 
-	// The size of the model parameters
-	ParameterSize uint64 `json:"parameterSize,omitempty"`
+	// The size of the model parameters, such as "8b", "16b", "32b", etc.
+	ParamSize string `json:"paramSize,omitempty"`
 
 	// The model precision, such as bf16, fp16, int8, mixed etc.
 	Precision string `json:"precision,omitempty"`


### PR DESCRIPTION
This pull request includes changes to update the terminology and format for specifying model parameter sizes across documentation and code. The most important changes include renaming `parameterSize` to `paramSize` and updating corresponding descriptions and examples.

Terminology and format updates:

* [`docs/config.md`](diffhunk://#diff-77b3519370ff48f6caf7c316f0ece966f2f0871c40e9381d451d2c5b1c76b40fL82-R84): Renamed `parameterSize` to `paramSize` and updated the description to reflect the new format, such as "8b", "16b", "32b", etc. [[1]](diffhunk://#diff-77b3519370ff48f6caf7c316f0ece966f2f0871c40e9381d451d2c5b1c76b40fL82-R84) [[2]](diffhunk://#diff-77b3519370ff48f6caf7c316f0ece966f2f0871c40e9381d451d2c5b1c76b40fL129-R129)
* [`specs-go/v1/config.go`](diffhunk://#diff-c2ec7789f5fa73b8405128e019d8ce01be92e7d1ade71ebd675160bbd6cb5048L34-R35): Updated the `ModelConfig` struct to use `ParamSize` instead of `ParameterSize` and modified the description accordingly.

Documentation fixes:

* [`docs/spec.md`](diffhunk://#diff-d7d183da3129291ef1210410b2898ac6a65a4e4de8ede9775601173545570f57L88-R88): Corrected the JSON syntax in the example image manifest by adding a missing comma.