### PR TITLE
feat: define the file information for each layer

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -99,6 +99,10 @@ The following terms are used in this section:
 
     Must be set to "layers".
 
+  - **file_infos** _object_, REQUIRED
+
+    Specifies the file information for each layer. The key is the digest of the layer content, and the value is the file information (`os.FileInfo`) for that layer, including metadata such as file size, permissions, modification time, etc.
+
   - **diff_ids** _array of strings_, REQUIRED
 
     An array of layer content hashes (`DiffIDs`), in order from first to last.

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -17,6 +17,7 @@
 package v1
 
 import (
+	"os"
 	"time"
 
 	digest "github.com/opencontainers/go-digest"
@@ -45,6 +46,10 @@ type ModelConfig struct {
 type ModelFS struct {
 	// Type is the type of the rootfs. MUST be set to "layers".
 	Type string `json:"type"`
+
+	// FileInfos is a collection of file information for the layer. The key is the digest of the layer and the value is the
+	// file information for the layer.
+	FileInfos map[digest.Digest]os.FileInfo `json:"file_infos"`
 
 	// DiffIDs is an array of layer content hashes (DiffIDs), in order from bottom-most to top-most.
 	DiffIDs []digest.Digest `json:"diff_ids"`


### PR DESCRIPTION
If the format is `raw`, the file information needs to be stored. `FileInfos` stores file information collections for each layer. The key is the digest of the layer content, and the value is the file information (os.FileInfo) for that layer, including metadata such as file size, permissions, and modification time.