### PR TITLE
add json schema for model config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: validate-examples
+validate-examples: ## validate examples in the specification markdown files
+	go test ./schema/example_test.go
+
+.PHONY: test
+test:
+	go test ./...

--- a/docs/config.md
+++ b/docs/config.md
@@ -107,7 +107,7 @@ The following terms are used in this section:
 
 Here is an example model artifact configuration JSON document:
 
-```json
+```json,title=Model%20Config%20JSON&mediatype=application/vnd.cnai.model.config.v1%2Bjson
 {
   "descriptor": {
     "createdAt": "2025-01-01T00:00:00Z",

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/CloudNativeAI/model-spec
 
 go 1.23.1
 
-require github.com/opencontainers/go-digest v1.0.0
+require (
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/russross/blackfriday v1.6.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
+github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -1,0 +1,117 @@
+{
+    "description": "Model Artifact Configuration Schema",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://github.com/CloudNativeAI/model-spec/config",
+    "type": "object",
+    "properties": {
+      "descriptor": {
+        "$ref": "#/$defs/ModelDescriptor"
+      },
+      "modelfs": {
+        "$ref": "#/$defs/ModelFS"
+      },
+      "config": {
+        "$ref": "#/$defs/ModelConfig"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "descriptor",
+      "config",
+      "modelfs"
+    ],
+    "$defs": {
+      "ModelConfig": {
+        "type": "object",
+        "properties": {
+          "architecture": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "paramSize": {
+            "type": "string"
+          },
+          "precision": {
+            "type": "string"
+          },
+          "quantization": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ModelDescriptor": {
+        "type": "object",
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "authors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "family": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "docURL": {
+            "type": "string"
+          },
+          "sourceURL": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "licenses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ModelFS": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["layers"]
+          },
+          "diff_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "type",
+          "diff_ids"
+        ]
+      }
+    }
+  }

--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -1,0 +1,315 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/CloudNativeAI/model-spec/schema"
+)
+
+func TestConfig(t *testing.T) {
+	for i, tt := range []struct {
+		config string
+		fail   bool
+	}{
+		// expected failure: config is missing
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: version is a number
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": 3.1
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: revision is a number
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1",
+    "revision": 1234567890
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: createdAt is not RFC3339 format
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1",
+    "createdAt": "2025/01/01T00:00:00Z"
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: authors is not an array
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1",
+	"authors": "John Doe"
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: licenses is not an array
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1",
+	"licenses": "Apache-2.0"
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: docURL is an array
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1",
+    "docURL": [
+       "https://example.com/doc"
+    ]
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: sourceURL is an array
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1",
+    "sourceURL": [
+       "https://github.com/xyz/xyz3"
+    ]
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: paramSize is a number
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1"
+  },
+  "config": {
+     "paramSize": 8000000
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: precision is a number
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1"
+  },
+  "config": {
+     "precision": 16
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: type is not "layers"
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1"
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layer",
+    "diff_ids": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: diff_ids is not an array
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1"
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+  }
+}
+`,
+			fail: true,
+		},
+		// expected failure: diff_ids is empty
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1"
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diff_ids": []
+  }
+}
+`,
+			fail: true,
+		},
+	} {
+		r := strings.NewReader(tt.config)
+		err := schema.ValidatorMediaTypeModelConfig.Validate(r)
+
+		if got := err != nil; tt.fail != got {
+			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)
+		}
+	}
+}

--- a/schema/example_test.go
+++ b/schema/example_test.go
@@ -1,0 +1,154 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/CloudNativeAI/model-spec/schema"
+	"github.com/russross/blackfriday"
+)
+
+var (
+	errFormatInvalid = errors.New("format: invalid")
+)
+
+func TestValidateConfigExample(t *testing.T) {
+	validate(t, "../docs/config.md")
+}
+
+func validate(t *testing.T, name string) {
+	m, err := os.Open(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	examples, err := extractExamples(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, example := range examples {
+		if errors.Is(example.Err, errFormatInvalid) && example.Mediatype == "" { // ignore
+			continue
+		}
+
+		if example.Err != nil {
+			printFields(t, "error", example.Mediatype, example.Title, example.Err)
+			t.Error(err)
+			continue
+		}
+
+		err = schema.Validator(example.Mediatype).Validate(strings.NewReader(example.Body))
+		if err == nil {
+			printFields(t, "ok", example.Mediatype, example.Title)
+		} else {
+			printFields(t, "error", example.Mediatype, example.Title, err)
+			t.Error(err)
+		}
+		t.Log(example.Body, "---")
+	}
+}
+
+// renderer allows one to incercept fenced blocks in markdown documents.
+type renderer struct {
+	blackfriday.Renderer
+	fn func(text []byte, lang string)
+}
+
+func (r *renderer) BlockCode(out *bytes.Buffer, text []byte, lang string) {
+	r.fn(text, lang)
+	r.Renderer.BlockCode(out, text, lang)
+}
+
+type example struct {
+	Lang      string // gets raw "lang" field
+	Title     string
+	Mediatype string
+	Body      string
+	Err       error
+}
+
+// parseExample treats the field as a syntax,attribute tuple separated by a comma.
+// Attributes are encoded as a url values.
+//
+// An example of this is `json,title=Foo%20Bar&mediatype=application/json. We
+// get that the "lang" is json, the title is "Foo Bar" and the mediatype is
+// "application/json".
+//
+// This preserves syntax highlighting and lets us tag examples with further
+// metadata.
+func parseExample(lang, body string) (e example) {
+	e.Lang = lang
+	e.Body = body
+
+	parts := strings.SplitN(lang, ",", 2)
+	if len(parts) < 2 {
+		e.Err = errFormatInvalid
+		return
+	}
+
+	m, err := url.ParseQuery(parts[1])
+	if err != nil {
+		e.Err = err
+		return
+	}
+
+	e.Mediatype = m.Get("mediatype")
+	e.Title = m.Get("title")
+	return
+}
+
+func extractExamples(rd io.Reader) ([]example, error) {
+	p, err := io.ReadAll(rd)
+	if err != nil {
+		return nil, err
+	}
+
+	var examples []example
+	renderer := &renderer{
+		Renderer: blackfriday.HtmlRenderer(0, "test test", ""),
+		fn: func(text []byte, lang string) {
+			examples = append(examples, parseExample(lang, string(text)))
+		},
+	}
+
+	// just pass over the markdown and ignore the rendered result. We just want
+	// the side-effect of calling back for each code block.
+	blackfriday.MarkdownOptions(p, renderer, blackfriday.Options{
+		Extensions: blackfriday.EXTENSION_FENCED_CODE,
+	})
+
+	return examples, nil
+}
+
+// printFields prints each value tab separated.
+func printFields(t *testing.T, vs ...interface{}) {
+	var ss []string
+	for _, f := range vs {
+		ss = append(ss, fmt.Sprint(f))
+	}
+	t.Log(strings.Join(ss, "\t"))
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,0 +1,53 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+import (
+	"embed"
+	"net/http"
+
+	v1 "github.com/CloudNativeAI/model-spec/specs-go/v1"
+)
+
+// Media types for the model-spec related formats
+const (
+	ValidatorMediaTypeModelConfig Validator = v1.MediaTypeModelConfig
+)
+
+var (
+	// specFS stores the embedded http.FileSystem having the model-spec related JSON schema files in root "/".
+	//go:embed *.json
+	specFS embed.FS
+
+	// specs maps model-spec schema media types to schema files.
+	specs = map[Validator]string{
+		ValidatorMediaTypeModelConfig: "config-schema.json",
+	}
+
+	// specURLs lists the various URLs a given spec may be known by.
+	specURLs = map[string][]string{
+		"config-schema.json": {
+			"https://github.com/CloudNativeAI/model-spec/config",
+		},
+	}
+)
+
+// FileSystem returns an in-memory filesystem including the schema files.
+// The schema files are located at the root directory.
+func FileSystem() http.FileSystem {
+	return http.FS(specFS)
+}

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -1,0 +1,125 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	v1 "github.com/CloudNativeAI/model-spec/specs-go/v1"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// Validator wraps a media type string identifier and implements validation against a JSON schema.
+type Validator string
+
+// Validate validates the given reader against the schema of the wrapped media type.
+func (v Validator) Validate(src io.Reader) error {
+	// run the media type specific validation
+	if fn, ok := validateByMediaType[v]; ok {
+		if fn == nil {
+			return fmt.Errorf("internal error: mapValidate is nil for %s", string(v))
+		}
+		// buffer the src so the media type validation and the schema validation can both read it
+		buf, err := io.ReadAll(src)
+		if err != nil {
+			return fmt.Errorf("failed to read input: %w", err)
+		}
+		src = bytes.NewReader(buf)
+		err = fn(buf)
+		if err != nil {
+			return err
+		}
+	}
+
+	// json schema validation
+	return v.validateSchema(src)
+}
+
+func (v Validator) validateSchema(src io.Reader) error {
+	if _, ok := specs[v]; !ok {
+		return fmt.Errorf("no validator available for %s", string(v))
+	}
+
+	c := jsonschema.NewCompiler()
+
+	// load the schema files from the embedded FS
+	dir, err := specFS.ReadDir(".")
+	if err != nil {
+		return fmt.Errorf("spec embedded directory could not be loaded: %w", err)
+	}
+	for _, file := range dir {
+		if file.IsDir() {
+			continue
+		}
+		specBuf, err := specFS.ReadFile(file.Name())
+		if err != nil {
+			return fmt.Errorf("could not read spec file %s: %w", file.Name(), err)
+		}
+		err = c.AddResource(file.Name(), bytes.NewReader(specBuf))
+		if err != nil {
+			return fmt.Errorf("failed to add spec file %s: %w", file.Name(), err)
+		}
+		if len(specURLs[file.Name()]) == 0 {
+			// this would be a bug in the validation code itself, add any missing entry to schema.go
+			return fmt.Errorf("spec file has no aliases: %s", file.Name())
+		}
+		for _, specURL := range specURLs[file.Name()] {
+			err = c.AddResource(specURL, bytes.NewReader(specBuf))
+			if err != nil {
+				return fmt.Errorf("failed to add spec file %s as url %s: %w", file.Name(), specURL, err)
+			}
+		}
+	}
+
+	// compile based on the type of validator
+	schema, err := c.Compile(specs[v])
+	if err != nil {
+		return fmt.Errorf("failed to compile schema %s: %w", string(v), err)
+	}
+
+	// read in the user input and validate
+	var input interface{}
+	err = json.NewDecoder(src).Decode(&input)
+	if err != nil {
+		return fmt.Errorf("unable to parse json to validate: %w", err)
+	}
+	err = schema.Validate(input)
+	if err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+	return nil
+}
+
+type validateFunc func([]byte) error
+
+var validateByMediaType = map[Validator]validateFunc{
+	ValidatorMediaTypeModelConfig: validateConfig,
+}
+
+func validateConfig(buf []byte) error {
+	mc := v1.ModelConfig{}
+
+	err := json.Unmarshal(buf, &mc)
+	if err != nil {
+		return fmt.Errorf("config format mismatch: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
fix: https://github.com/CloudNativeAI/model-spec/issues/46

### NOTE for Reviewers:

1. I was unable to find any auto generation involved from json schema to  Go structs or vice versa in image-spec.
2. The logic related to the schema in the `image-spec` repo primarily focuses on (example) validation and Go testing.

This PR attempts to align with that validation and testing logic from image-spec.

### Go files introduced

To mirror the structure of the `image-spec` repo, I’ve introduced the following Go files with some minor adjustments based on my own understanding:
| `model-spec`               | `image-spec`             | Role                                      |
|----------------------------|---------------------------|-------------------------------------------|
| `schema/schema.go`         | `schema/schema.go`        | Go metadata definition for the schema     |
| `schema/validator.go`      | `schema/validator.go`     | Go utility package to validate JSONs |
| `schema/config_test.go`    | `schema/config_test.go`   | Use `schema/validator.go`to test the config json schema with a variety of intentionally common mistakes and edge-cases config JSON examples       |
| `schema/example_test.go`   | `schema/spec_test.go`     | Markdown examples validation              |


**note**:

1. I renamed `schema/spec_test.go` (from image-spec) to `schema/example_test.go` in this repo. In image-spec, `spec_test.go` validates the examples embedded in Markdown files, but the name is a bit ambiguous. The renaming helps clarify the purpose of the file here.
2. I’ve taken most of the code directly from the image-spec and temporarily removed any unused code, such as those related to other specs like `layout`.

### NOTE for the JSON Schema file

For the JSON Schema definition in `config-schema.json`, I have embedded validation rules directly within the schema to make it **self-contained** and ensure consistent validation behavior across different languages.

This  differs from `image-spec`, where additional validation rules are implemented in Go code (`schema/validator.go`) rather than encoded in the JSON schema definition itself. 
For example, there is an environment variable regex validation in image-spec for the config. This validation is performed in Go code:: https://github.com/opencontainers/image-spec/blob/main/schema/validator.go#L180-L185
But this validation is **not** explicitly defined in the JSON Schema:
https://github.com/opencontainers/image-spec/blob/main/schema/config-schema.json#L41-L45
I don't think it is a good idea. Thats why I changed it in this repo.

### Additional Validation Rules Enforced in This Schema Besides `config.md`

I embedded the following validation rules directly into the JSON Schema:
- In `modelfs`:
  - `type` must be exactly `"layers"` (enforced via `"enum"`)
  - `diff_ids` must be a non-empty array (enforced via `"minItems": 1`)


