### PR TITLE
feat: add the type definition of file metadata annotation

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -7,3 +7,35 @@ This property contains arbitrary metadata, and SHOULD follow the rules of [OCI i
 ### Layer Annotation Keys
 
 - **`org.cnai.model.filepath`**: Specifies the file path of the layer (string).
+
+- **`org.cnai.model.file.metadata`**: Specifies the metadata of the file (string), value is the JSON string of [File Metadata Annotation Value](#File-Metadata-Annotation-Value).
+
+### Layer Annotation Values
+
+#### File Metadata Annotation Value
+
+```go
+// FileMetadata represents the metadata of file, which is the value definition of AnnotationFileMetadata.
+type FileMetadata struct {
+	// File name
+	Name string `json:"name"`
+
+	// File permission mode (e.g., Unix permission bits)
+	Mode uint32 `json:"mode"`
+
+	// User ID (identifier of the file owner)
+	Uid uint32 `json:"uid"`
+
+	// Group ID (identifier of the file's group)
+	Gid uint32 `json:"gid"`
+
+	// File size (in bytes)
+	Size int64 `json:"size"`
+
+	// File last modification time
+	ModTime time.Time `json:"mtime"`
+
+	// File type flag (e.g., regular file, directory, etc.)
+	Typeflag byte `json:"typeflag"`
+}
+```

--- a/specs-go/v1/annotations.go
+++ b/specs-go/v1/annotations.go
@@ -16,7 +16,36 @@
 
 package v1
 
+import "time"
+
 const (
 	// AnnotationFilepath is the annotation key for the file path of the layer.
 	AnnotationFilepath = "org.cnai.model.filepath"
+
+	// AnnotationFileMetadata is the annotation key for the file metadata of the layer.
+	AnnotationFileMetadata = "org.cnai.model.file.metadata"
 )
+
+// FileMetadata represents the metadata of file, which is the value definition of AnnotationFileMetadata.
+type FileMetadata struct {
+	// File name
+	Name string `json:"name"`
+
+	// File permission mode (e.g., Unix permission bits)
+	Mode uint32 `json:"mode"`
+
+	// User ID (identifier of the file owner)
+	Uid uint32 `json:"uid"`
+
+	// Group ID (identifier of the file's group)
+	Gid uint32 `json:"gid"`
+
+	// File size (in bytes)
+	Size int64 `json:"size"`
+
+	// File last modification time
+	ModTime time.Time `json:"mtime"`
+
+	// File type flag (e.g., regular file, directory, etc.)
+	Typeflag byte `json:"typeflag"`
+}


### PR DESCRIPTION
This pull request introduces a new annotation key and its associated metadata structure to enhance file layer annotations. The most important changes include the addition of `AnnotationFileMetadata` and the definition of the `FileMetadata` struct to describe file-specific metadata.

### Enhancements to file layer annotations:

* **New annotation key added**: Introduced `org.cnai.model.file.metadata` as a new annotation key to specify file metadata in JSON format. [[1]](diffhunk://#diff-d210c46f7c35fae8f95ec8111564cc357a038b0ec63128f7707f31087a6f7115R10-R41) [[2]](diffhunk://#diff-05a9698dc79be9f08ba5b6fbbaa6bb013a61c3b2db9b5cd1aa570677f7065c0cR19-R51)
* **Definition of `FileMetadata` struct**: Added a `FileMetadata` struct in `specs-go/v1/annotations.go` to define the metadata schema, including file name, permission mode, owner and group IDs, size, modification time, and type flag.
* **Documentation update**: Updated `docs/annotations.md` to document the new annotation key and provide details about the `FileMetadata` structure.

Closes https://github.com/CloudNativeAI/model-spec/issues/44.