### PR TITLE
proposal: use `+json` postfix to mark json annotation values

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -8,7 +8,7 @@ This property contains arbitrary metadata, and SHOULD follow the rules of [OCI i
 
 - **`org.cnai.model.filepath`**: Specifies the file path of the layer (string).
 
-- **`org.cnai.model.file.metadata`**: Specifies the metadata of the file (string), value is the JSON string of [File Metadata Annotation Value](#File-Metadata-Annotation-Value).
+- **`org.cnai.model.file.metadata+json`**: Specifies the metadata of the file (string), value is the JSON string of [File Metadata Annotation Value](#File-Metadata-Annotation-Value).
 
 ### Layer Annotation Values
 

--- a/specs-go/v1/annotations.go
+++ b/specs-go/v1/annotations.go
@@ -23,7 +23,7 @@ const (
 	AnnotationFilepath = "org.cnai.model.filepath"
 
 	// AnnotationFileMetadata is the annotation key for the file metadata of the layer.
-	AnnotationFileMetadata = "org.cnai.model.file.metadata"
+	AnnotationFileMetadata = "org.cnai.model.file.metadata+json"
 )
 
 // FileMetadata represents the metadata of file, which is the value definition of AnnotationFileMetadata.


### PR DESCRIPTION
Hi,
I'm following up to what was presented yesterday call, with https://github.com/CloudNativeAI/model-spec/issues/44, https://github.com/CloudNativeAI/model-spec/issues/49

I'd like to propose a more explicit way to distinguish annotations that are holding a string-based-representation of a known format which is not a pure string scalar, in this case string-based-representation of a JSON object.

This stems from the fact that in OCI spec, Annotations are indeed key-value pair of str-str scalars only.
ref https://github.com/opencontainers/image-spec/blob/64294bd7a2bf2537e1a6a34d687caae70300b0c4/annotations.md?plain=1#L9

I think using a string representation of a structured JSON object in the value is more than fine,
but imho we can make it even more explicit beyond writing in the document:
> value is the JSON string

ref https://github.com/CloudNativeAI/model-spec/blob/main/docs/annotations.md?plain=1#L11C84-L11C108

by using a conventional `+suffix` making it even prominent without referring to the doc itself.

wdyt?