### PR TITLE
spec: add capabilities field to model config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -67,6 +67,10 @@ The following terms are used in this section:
 
     A list of licenses under which the model is distributed, represented as [SPDX License Expressions][spdx-license-expression].
 
+  - **capabilities** _array of string_, OPTIONAL
+
+    A list of special capabilities that the model supports, such as "reasoning", "multimodal".
+
 - **config** _object_, REQUIRED
 
   Contains the technical metadata for the model.

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -87,6 +87,9 @@ type ModelDescriptor struct {
 
 	// The human-readable description of the software packaged in the model
 	Description string `json:"description,omitempty"`
+
+	// Special capabilities that the model supports, such as "reasoning", "multimodal".
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // Model defines the basic information of a model.


### PR DESCRIPTION
We can use it to tell some key special capabilities of a model.