### PR TITLE
config: add languages capability

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -175,6 +175,10 @@ The following terms are used in this section:
 
     Whether the model is a reward model.
 
+  - **languages** _array of string_, OPTIONAL
+
+    What languages can the model speak. Encoded as [ISO 639][iso-639] two letter codes.
+
 ## Example
 
 Here is an example model artifact configuration JSON document:
@@ -217,7 +221,8 @@ Here is an example model artifact configuration JSON document:
       "reasoning": true,
       "toolUsage": false,
       "embedding": false,
-      "reward": false
+      "reward": false,
+      "languages": ["en", "zh"]
     }
   },
   "modelfs": {
@@ -233,3 +238,4 @@ Here is an example model artifact configuration JSON document:
 [oci-media-type]: https://github.com/opencontainers/image-spec/blob/main/descriptor.md#properties
 [rfc3339-s5.6]: https://tools.ietf.org/html/rfc3339#section-5.6
 [spdx-license-expression]: https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/
+[iso-639]: https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -129,6 +129,10 @@ type ModelCapabilities struct {
 
 	// Reward indicates whether the model is a reward model
 	Reward *bool `json:"reward,omitempty"`
+
+	// Language indicates the languages that the model can speak.
+	// Encoded as ISO 639 two letter codes. For example, ["en", "fr", "zh"].
+	Languages []string `json:"languages,omitempty"`
 }
 
 // Model defines the basic information of a model.


### PR DESCRIPTION
The field is borrowed from https://github.com/ggml-org/ggml/blob/master/docs/gguf.md#general-metadata:
> general.languages


The PR can be considered as part of  #55.