### PR TITLE
fix: align json-schema to current specs-go/v1/config.go

### DIFF
--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -38,9 +38,44 @@
           },
           "quantization": {
             "type": "string"
+          },
+          "capabilities": {
+            "$ref": "#/$defs/ModelCapabilities"
           }
         },
         "additionalProperties": false
+      },
+      "ModelCapabilities": {
+        "type": "object",
+        "properties": {
+          "inputTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/Modality"
+            }
+          },
+          "outputTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/Modality"
+            }
+          },
+          "knowledgeCutoff": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reasoning": {
+            "type": "boolean"
+          },
+          "toolUsage": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Modality": {
+        "type": "string",
+        "enum": ["text", "image", "audio", "video", "embedding", "other"]
       },
       "ModelDescriptor": {
         "type": "object",
@@ -99,7 +134,7 @@
             "type": "string",
             "enum": ["layers"]
           },
-          "diff_ids": {
+          "diffIds": {
             "type": "array",
             "items": {
               "type": "string"
@@ -110,7 +145,7 @@
         "additionalProperties": false,
         "required": [
           "type",
-          "diff_ids"
+          "diffIds"
         ]
       }
     }

--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -38,7 +38,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -59,7 +59,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -81,7 +81,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -103,7 +103,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -125,7 +125,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -147,7 +147,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -171,7 +171,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -195,7 +195,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -216,7 +216,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -237,7 +237,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -258,7 +258,7 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layer",
-    "diff_ids": [
+    "diffIds": [
        "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     ]
   }
@@ -266,7 +266,7 @@ func TestConfig(t *testing.T) {
 `,
 			fail: true,
 		},
-		// expected failure: diff_ids is not an array
+		// expected failure: diffIds is not an array
 		{
 			config: `
 {
@@ -279,13 +279,13 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    "diffIds": "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
   }
 }
 `,
 			fail: true,
 		},
-		// expected failure: diff_ids is empty
+		// expected failure: diffIds is empty
 		{
 			config: `
 {
@@ -298,11 +298,32 @@ func TestConfig(t *testing.T) {
   },
   "modelfs": {
     "type": "layers",
-    "diff_ids": []
+    "diffIds": []
   }
 }
 `,
 			fail: true,
+		},
+		// example Positive test, expected to pass schema validation
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1"
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diffIds": [
+      "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: false,
 		},
 	} {
 		r := strings.NewReader(tt.config)


### PR DESCRIPTION
- Add "capabilities" to the JSON schema
ref: https://github.com/modelpack/model-spec/blob/e68cd2690299996ca00197235a037640400efc05/docs/config.md?plain=1#L107
effectively follow-up to https://github.com/modelpack/model-spec/pull/52
- Rename `diff_ids` to `diffIds` for consistency with specs-go/v1/config.go
ref: https://github.com/modelpack/model-spec/blob/e68cd2690299996ca00197235a037640400efc05/specs-go/v1/config.go#L53
- Update test cases to use reflect `diffIds` field name
- Add positive test case to config_test

