### PR TITLE
fix: updating the specification file to correctly describe the `application/vnd.cncf.model.weight.config.v1.raw` mediaType

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -50,7 +50,7 @@ The image manifest of model artifacts follows the [OCI Image Manifest Specificat
 
     - `application/vnd.cncf.model.weight.v1.tar+zstd`: The layer is a [tar archive][tar-archive] that includes the configuration file for the model weights. The archive is compressed with [zstd][rfc8478].
 
-    - `application/vnd.cncf.model.weight.config.v1.raw`: The layer is a [tar archive][tar-archive] that includes config of the model weights like tokenizer.json, config.json, etc.
+    - `application/vnd.cncf.model.weight.config.v1.raw`: The layer is an unarchived, uncompressed config of the model weights like tokenizer.json, config.json, etc.
 
     - `application/vnd.cncf.model.weight.config.v1.tar`: The layer is a [tar archive][tar-archive] that includes config of the model weights like tokenizer.json, config.json, etc.
 


### PR DESCRIPTION
## Description

This commit makes changes to avoid repeatation of the `application/vnd.cncf.model.weight.config.v1.tar` into `application/vnd.cncf.model.weight.config.v1.raw` mediaType in spec.md file and uses the description provided in mediatype.go to provide right description.

## Related Issue

https://github.com/modelpack/model-spec/issues/132

## Motivation and Context

I was recently learning about Docker Model runner and how they are using OCI specification for models. This led me to ModelPack and being interested in learning more about, I started learning about the spec and how is it adopting the OCI for model artifiact.

During this deep dive, I found repeatation in description of mediaType. To solve this, I made changes to keep the specs.md file mediaTypes description file inline with their intended purpose.
