### PR TITLE
docs: move capabilities fields to correct location under config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -135,6 +135,36 @@ The following terms are used in this section:
 
     Special capabilities that the model supports, such as reasoning, toolusage, etc.
 
+    - **inputTypes** _array of string_, OPTIONAL
+
+      An array of strings specifying the data types that the model can accept as input.
+      The allowed values are: "text", "image", "audio", "video", or "embedding". For input types that are not explicitly defined, the value "other" value should be used.
+
+    - **outputTypes** _array of string_, OPTIONAL
+
+      An array of strings specifying the data types that the model can produce as output.
+      The allowed values are: "text", "image", "audio", "video", or "embedding". For output types that are not explicitly defined, the value "other" value should be used.
+
+    - **knowledgeCutoff** _string_, OPTIONAL
+
+      The date and time of the datasets that the model was trained on, formatted as defined by [RFC 3339, section 5.6][rfc3339-s5.6].
+
+    - **reasoning** _boolean_, OPTIONAL
+
+      Whether the model can perform reasoning tasks.
+
+    - **toolUsage** _boolean_, OPTIONAL
+
+      Whether the model can use external tools or APIs to perform tasks.
+
+    - **reward** _boolean_, OPTIONAL
+
+      Whether the model is a reward model.
+
+    - **languages** _array of string_, OPTIONAL
+
+      What languages can the model speak. Encoded as [ISO 639][iso-639] two letter codes.
+
 - **modelfs** _object_, REQUIRED
 
   Contains hashes of each uncompressed layer's content.
@@ -146,40 +176,6 @@ The following terms are used in this section:
   - **diffIds** _array of strings_, REQUIRED
 
     An array of layer content hashes (`DiffIDs`), in order from first to last.
-
-- **capabilities** _object_, OPTIONAL
-
-    Special capabilities that the model supports, such as reasoning, toolusage, etc.
-
-  - **inputTypes** _array of string_, OPTIONAL
-
-    An array of strings specifying the data types that the model can accept as input.
-    The allowed values are: "text", "image", "audio", "video", or "embedding". For input types that are not explicitly defined, the value "other" value should be used.
-
-  - **outputTypes** _array of string_, OPTIONAL
-
-    An array of strings specifying the data types that the model can produce as output.
-    The allowed values are: "text", "image", "audio", "video", or "embedding". For output types that are not explicitly defined, the value "other" value should be used.
-
-  - **knowledgeCutoff** _string_, OPTIONAL
-
-    The date and time of the datasets that the model was trained on, formatted as defined by [RFC 3339, section 5.6][rfc3339-s5.6].
-
-  - **reasoning** _boolean_, OPTIONAL
-
-    Whether the model can perform reasoning tasks.
-
-  - **toolUsage** _boolean_, OPTIONAL
-
-    Whether the model can use external tools or APIs to perform tasks.
-
-  - **reward** _boolean_, OPTIONAL
-
-    Whether the model is a reward model.
-
-  - **languages** _array of string_, OPTIONAL
-
-    What languages can the model speak. Encoded as [ISO 639][iso-639] two letter codes.
 
 ## Example
 


### PR DESCRIPTION
## Description

This PR fixes a structural inconsistency in the config.md documentation where the `capabilities` object and its child properties were incorrectly defined at the top level instead of being nested under the `config` object.

**Changes made:**
- Moved all `capabilities` sub-properties (`inputTypes`, `outputTypes`, `knowledgeCutoff`, `reasoning`, `toolUsage`, `reward`, `languages`) from the incorrect top-level `capabilities` section to the correct location under `config.capabilities`
- Removed the duplicate top-level `capabilities` definition (lines 150-182)
- The documentation structure now correctly matches the example JSON provided in the same file

## Related Issue

<!--- Please link to the issue here if applicable -->

## Motivation and Context

The documentation had a structural error where `capabilities` was defined twice:
1. First as `config.capabilities` (line 134-136) with only a brief description
2. Then as a top-level `capabilities` object (line 150-182) with all the detailed sub-properties

However, the example JSON in the document (lines 215-228) shows that `capabilities` should be nested under `config`, not at the top level. This inconsistency could confuse users implementing the specification.

This fix ensures the documentation structure aligns with the actual JSON schema, making it clear that the correct path is `config.capabilities.*` rather than top-level `capabilities.*`.