### PR TITLE
chore(ci): add missing version comments to GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,15 +16,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: go.mod
           cache: false
 
       - name: Golangci lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.1.0
           args: --verbose


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add missing version comments to `actions/checkout` (v6.0.1) and `actions/setup-go` (v6.1.0)
- Pin `golangci/golangci-lint-action` to SHA with version comment (v9.2.0)

- Fixes: #155 
<!--- Describe your changes in detail -->

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


<!--- Why is this change required? What problem does it solve? -->
