### PR TITLE
fix(schema): use v1.Model instead of v1.ModelConfig in validateConfig

### DIFF
--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -580,6 +580,95 @@ func TestConfig(t *testing.T) {
 `,
 			fail: true,
 		},
+		// valid: minimal config with required fields only
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-3-8B-Instruct"
+  },
+  "config": {
+     "paramSize": "8b"
+  },
+  "modelfs": {
+    "type": "layers",
+    "diffIds": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: false,
+		},
+		// valid: full config with all optional fields populated
+		{
+			config: `
+{
+  "descriptor": {
+    "createdAt": "2025-01-01T00:00:00Z",
+    "authors": ["xyz@xyz.com"],
+    "vendor": "XYZ Corp.",
+    "family": "xyz3",
+    "name": "xyz-3-8B-Instruct",
+    "version": "3.1",
+    "title": "XYZ 3 8B Instruct",
+    "description": "xyz is a large language model.",
+    "docURL": "https://www.xyz.com/get-started/",
+    "sourceURL": "https://github.com/xyz/xyz3",
+    "datasetsURL": ["https://www.xyz.com/datasets/"],
+    "revision": "1234567890",
+    "licenses": ["Apache-2.0"]
+  },
+  "config": {
+    "architecture": "transformer",
+    "format": "safetensors",
+    "paramSize": "8b",
+    "precision": "float16",
+    "quantization": "gptq",
+    "capabilities": {
+      "inputTypes": ["text"],
+      "outputTypes": ["text"],
+      "knowledgeCutoff": "2024-05-21T00:00:00Z",
+      "reasoning": true,
+      "toolUsage": false
+    }
+  },
+  "modelfs": {
+    "type": "layers",
+    "diffIds": [
+      "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    ]
+  }
+}
+`,
+			fail: false,
+		},
+		// valid: multimodal model with image input and output
+		{
+			config: `
+{
+  "descriptor": {
+    "name": "xyz-vl-7B"
+  },
+  "config": {
+    "architecture": "transformer",
+    "paramSize": "7b",
+    "capabilities": {
+      "inputTypes": ["text", "image"],
+      "outputTypes": ["text", "image", "embedding"]
+    }
+  },
+  "modelfs": {
+    "type": "layers",
+    "diffIds": [
+       "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    ]
+  }
+}
+`,
+			fail: false,
+		},
 	} {
 		r := strings.NewReader(tt.config)
 		err := schema.ValidatorMediaTypeModelConfig.Validate(r)

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -114,9 +114,9 @@ var validateByMediaType = map[Validator]validateFunc{
 }
 
 func validateConfig(buf []byte) error {
-	mc := v1.ModelConfig{}
+	model := v1.Model{}
 
-	err := json.Unmarshal(buf, &mc)
+	err := json.Unmarshal(buf, &model)
 	if err != nil {
 		return fmt.Errorf("config format mismatch: %w", err)
 	}


### PR DESCRIPTION
## Summary
`validateConfig` was unmarshaling input into `v1.ModelConfig` (the inner config block) instead of `v1.Model` (the full document). Since `json.Unmarshal` silently ignores unknown fields, the pre-schema type check always succeeded — making it a no-op.

## Details
- **Problem:** `validateConfig` used `v1.ModelConfig{}` as the unmarshal target. A full `Model` JSON (with `descriptor`, `config`, `modelfs`) would unmarshal into the tiny `ModelConfig` struct without error, so structural mismatches were never caught at this stage.
- **Fix:** Changed the unmarshal target to `v1.Model{}` so the pre-validation actually checks the correct document shape.
- **Tests:** Added 3 positive test cases to `TestConfig` — previously all 17 cases asserted failure, so a validator that always errored would still pass the entire suite.

## Testing
\`\`\`
go test ./schema/ -run TestConfig -v   ✓ PASS
go test ./schema/ -run TestValidateConfigExample -v   ✓ PASS
go test ./...   ✓ PASS
\`\`\`