### PR TITLE
fix: update JSON schema from draft-04 to draft 2020-12

### DIFF
--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -1,6 +1,6 @@
 {
     "description": "Model Artifact Configuration Schema",
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/modelpack/model-spec/config",
     "type": "object",
     "properties": {

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -58,6 +58,7 @@ func (v Validator) validateSchema(src io.Reader) error {
 	}
 
 	c := jsonschema.NewCompiler()
+	c.AssertFormat = true
 
 	// load the schema files from the embedded FS
 	dir, err := specFS.ReadDir(".")


### PR DESCRIPTION
The schema declares draft-04 but uses keywords like $defs and $id which only exist in draft 2019-09+. Draft-04 uses definitions and id instead. This mismatch means strict draft-04 validators would ignore the type definitions entirely, causing silent validation failures for external consumers. Updated the $schema URI to draft 2020-12 and enabled format assertion in the validator since draft 2020-12 treats format as annotation-only by default.