### PR TITLE
fix(specs-go): remove omitempty from Model.Config json tag

### DIFF
--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -167,5 +167,5 @@ type Model struct {
 	ModelFS ModelFS `json:"modelfs"`
 
 	// Config defines the execution parameters which should be used as a base when running a model using an inference engine.
-	Config ModelConfig `json:"config,omitempty"`
+	Config ModelConfig `json:"config"`
 }


### PR DESCRIPTION
The JSON schema requires the config field to be present.
The Go Model struct allowed it to be omitted due to the omitempty tag.

This change removes omitempty to align the Go struct with the schema requirement.
