### PR TITLE
docs(config): align example precision and format with spec table

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -204,9 +204,9 @@ Here is an example model artifact configuration JSON document:
   },
   "config": {
     "architecture": "transformer",
-    "format": "pytorch",
+    "format": "pt",
     "paramSize": "8b",
-    "precision": "fp16",
+    "precision": "float16",
     "quantization": "gptq",
     "capabilities": {
       "inputTypes": [


### PR DESCRIPTION
The example in docs/config.md used values (fp16, pytorch) that did not match the documented precision and format values in the specification table.

This PR updates the example to use float16 and pt to ensure internal consistency.