### PR TITLE
ci: add GitHub Actions workflow for Python SDK

### DIFF
--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -1,0 +1,63 @@
+name: Python SDK
+
+on:
+  push:
+    branches: [main, release-*]
+    paths:
+      - 'specs-python/**'
+  pull_request:
+    branches: [main, release-*]
+    paths:
+      - 'specs-python/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e specs-python/[dev]
+
+      - name: Run tests
+        run: python -m pytest specs-python/tests/ -v
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Ruff check
+        run: ruff check specs-python/
+
+      - name: Ruff format check
+        run: ruff format --check specs-python/


### PR DESCRIPTION
Adds a CI workflow for the Python SDK introduced in #175. The workflow runs pytest across Python 3.10 through 3.13 to ensure compatibility, and uses ruff for linting and format checks. It is path-scoped to `specs-python/` so it only triggers when relevant files change, keeping CI runs efficient. Follows the same conventions as the existing `lint.yml` workflow with pinned action SHAs and minimal permissions.
