### PR TITLE
docs: add Docker Model Runner usage guide for ModelPack artifacts

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,6 +35,7 @@ This section lists the core infrastructure components that ModelPack is working 
 - **[modctl](https://github.com/modelpack/modctl)**: CLI tool for building, pushing, pulling, and managing OCI model artifacts
 - **[KitOps](https://kitops.ml/)**: ModelKit packaging and deployment platform that supports the ModelPack specification
 - **[AIKit](https://kaito-project.github.io/aikit/docs/packaging)**: Package AI models as OCI artifacts from local, HTTP, or Hugging Face sources with extensible formats, including ModelPack specification
+- **[Docker Model Runner guide](./modelpack.md)**: Run ModelPack artifacts with Docker Model Runner using its standard pull/run workflow
 
 ### Kubernetes Integration
 

--- a/docs/modelpack.md
+++ b/docs/modelpack.md
@@ -1,0 +1,36 @@
+# Running ModelPack Models with Docker Model Runner
+
+This guide explains how to run CNCF ModelPack artifacts with [Docker Model Runner](https://github.com/docker/model-runner).
+
+## What ModelPack compatibility means
+
+Docker Model Runner includes ModelPack compatibility introduced in [docker/model-runner#516](https://github.com/docker/model-runner/pull/516).
+
+This allows Docker Model Runner to pull and run model artifacts that follow the ModelPack specification while keeping the normal Docker Model Runner workflow.
+
+## Run a ModelPack model
+
+1. Package and push a model artifact using a ModelPack-compatible tool (for example, [modctl](https://github.com/modelpack/modctl) or [AIKit](https://kaito-project.github.io/aikit/docs/packaging)).
+2. Use the artifact reference from your OCI registry with Docker Model Runner.
+3. Run inference with Docker Model Runner.
+
+## Example workflow
+
+```bash
+# Example ModelPack artifact reference in an OCI registry
+MODEL_REF=registry.example.com/models/my-model:v1
+
+# Run inference via Docker Model Runner
+docker model run $MODEL_REF "Hello"
+```
+
+For additional CLI and API usage, see:
+
+- [docker/model-runner repository](https://github.com/docker/model-runner)
+- [Docker Model Runner docs](https://docs.docker.com/ai/model-runner/get-started/)
+
+## Compatibility notes
+
+- Use a Docker Model Runner version that includes [docker/model-runner#516](https://github.com/docker/model-runner/pull/516) or newer.
+- The model artifact must be a valid OCI artifact following the ModelPack specification.
+- Backend/runtime-specific behavior is defined by Docker Model Runner.


### PR DESCRIPTION
Add documentation describing how ModelPack artifacts can be used with Docker Model Runner.

This PR adds a guide explaining:
- what ModelPack compatibility in Docker Model Runner means
- how to run ModelPack artifacts using the Docker Model Runner workflow
- a simple example workflow using an OCI artifact reference

A link to this guide is also added in the Getting Started documentation to improve discoverability.

This addresses part of the remaining work discussed in:
https://github.com/modelpack/model-spec/issues/151