### PR TITLE
chore: add AI coding agent config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,12 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# AI coding agent config files
+CLAUDE.md
+AGENTS.md
+GEMINI.md
+.cursorrules
+.cursor/
+.windsurfrules
+.github/copilot-instructions.md


### PR DESCRIPTION
## Summary
- Add `.gitignore` entries for AI coding agent config files (Claude Code, Codex, Gemini CLI, Cursor, Windsurf, GitHub Copilot)
- Keeps the repository clean from tool-specific local configuration files

## Test plan
- [ ] Verify `.gitignore` correctly ignores the listed files
- [ ] Confirm no existing tracked files are affected