### PR TITLE
feat(schema): add minimal architecture_config for transformer models

### DIFF
--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -41,8 +41,34 @@
           },
           "capabilities": {
             "$ref": "#/$defs/ModelCapabilities"
+          },
+          "architecture_config": {
+            "$ref": "#/$defs/ArchitectureConfig"
           }
         },
+        "additionalProperties": false
+      },
+      "ArchitectureConfig": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["transformer"]
+          },
+          "numLayers": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "hiddenSize": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "numAttentionHeads": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": ["type", "numLayers", "hiddenSize", "numAttentionHeads"],
         "additionalProperties": false
       },
       "ModelDescriptor": {

--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -589,3 +589,51 @@ func TestConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestArchitectureConfigValid(t *testing.T) {
+	validJSON := `{
+		"descriptor": {"name": "test-model"},
+		"config": {
+			"paramSize": "8b",
+			"architecture_config": {
+				"type": "transformer",
+				"numLayers": 32,
+				"hiddenSize": 4096,
+				"numAttentionHeads": 32
+			}
+		},
+		"modelfs": {
+			"type": "layers",
+			"diffIds": ["sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"]
+		}
+	}`
+
+	err := schema.ValidatorMediaTypeModelConfig.Validate(strings.NewReader(validJSON))
+	if err != nil {
+		t.Fatalf("expected valid architecture_config to pass, got error: %v", err)
+	}
+}
+
+func TestArchitectureConfigMissingRequiredField(t *testing.T) {
+	// Missing numLayers field
+	invalidJSON := `{
+		"descriptor": {"name": "test-model"},
+		"config": {
+			"paramSize": "8b",
+			"architecture_config": {
+				"type": "transformer",
+				"hiddenSize": 4096,
+				"numAttentionHeads": 32
+			}
+		},
+		"modelfs": {
+			"type": "layers",
+			"diffIds": ["sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"]
+		}
+	}`
+
+	err := schema.ValidatorMediaTypeModelConfig.Validate(strings.NewReader(invalidJSON))
+	if err == nil {
+		t.Fatalf("expected architecture_config with missing numLayers to fail validation")
+	}
+}

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -42,6 +42,24 @@ type ModelConfig struct {
 
 	// Special capabilities that the model supports
 	Capabilities *ModelCapabilities `json:"capabilities,omitempty"`
+
+	// Architecture-specific configuration parameters
+	ArchitectureConfig *ArchitectureConfig `json:"architecture_config,omitempty"`
+}
+
+// ArchitectureConfig defines architecture-specific parameters for the model.
+type ArchitectureConfig struct {
+	// Type specifies the model architecture type (e.g., "transformer").
+	Type string `json:"type"`
+
+	// NumLayers is the number of layers in the model.
+	NumLayers int `json:"numLayers"`
+
+	// HiddenSize is the dimensionality of the hidden representations.
+	HiddenSize int `json:"hiddenSize"`
+
+	// NumAttentionHeads is the number of attention heads.
+	NumAttentionHeads int `json:"numAttentionHeads"`
 }
 
 // ModelFS describes a layer content addresses


### PR DESCRIPTION
### Summary
Add an optional `architecture_config` field to ModelConfig to represent basic transformer structure.

Context
There is ongoing work toward a unified transformer specification (#164), but the current spec has no place to store architecture-level information. This introduces a minimal starting point so that work can proceed incrementally.

**What’s included**
- New `ArchitectureConfig` struct in specs-go/v1/config.go
- Optional `architecture_config` field on ModelConfig (omitempty)
- JSON schema definition with required fields:
  - type (currently "transformer")
  - numLayers
  - hiddenSize
  - numAttentionHeads
- Validation tests:
  - valid configuration passes
  - missing required fields fail

**Design notes**
- Kept the structure intentionally minimal to avoid premature design decisions
- Restricted `type` to "transformer" for now
- Used pointer to preserve existing serialization behavior
- Schema is strict (no additionalProperties)

**Out of scope**
- Full transformer architecture modeling
- External integrations (e.g., HuggingFace)
- Runtime concerns

**Follow-up**
This enables future work on:
- extending architecture schema
- generating configs from models
- end-to-end validation