### PR TITLE
fix: correct typo and mismatched godoc comment names

### DIFF
--- a/schema/example_test.go
+++ b/schema/example_test.go
@@ -72,7 +72,7 @@ func validate(t *testing.T, name string) {
 	}
 }
 
-// renderer allows one to incercept fenced blocks in markdown documents.
+// renderer allows one to intercept fenced blocks in markdown documents.
 type renderer struct {
 	blackfriday.Renderer
 	fn func(text []byte, lang string)

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -37,16 +37,16 @@ const (
 	// MediaTypeModelWeightZstd is the media type used for zstd compressed model weights.
 	MediaTypeModelWeightZstd = "application/vnd.cncf.model.weight.v1.tar+zstd"
 
-	// MediaTypeModelWeightConfigRaw is the media type used for an unarchived, uncompressed model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfigRaw is the media type used for an unarchived, uncompressed configuration of the model weights, including files like `tokenizer.json`, etc.
 	MediaTypeModelWeightConfigRaw = "application/vnd.cncf.model.weight.config.v1.raw"
 
-	// MediaTypeModelWeightConfig specifies the media type for configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfig specifies the media type for configuration of the model weights, including files like `tokenizer.json`, etc.
 	MediaTypeModelWeightConfig = "application/vnd.cncf.model.weight.config.v1.tar"
 
-	// MediaTypeModelWeightConfigGzip specifies the media type for gzipped configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfigGzip specifies the media type for gzipped configuration of the model weights, including files like `tokenizer.json`, etc.
 	MediaTypeModelWeightConfigGzip = "application/vnd.cncf.model.weight.config.v1.tar+gzip"
 
-	// MediaTypeModelWeightConfigZstd specifies the media type for zstd compressed configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfigZstd specifies the media type for zstd compressed configuration of the model weights, including files like `tokenizer.json`, etc.
 	MediaTypeModelWeightConfigZstd = "application/vnd.cncf.model.weight.config.v1.tar+zstd"
 
 	// MediaTypeModelDocRaw is the media type used for an unarchived, uncompressed model documentation, including documentation files like `README.md`, `LICENSE`, etc.

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -40,13 +40,13 @@ const (
 	// MediaTypeModelWeightConfigRaw is the media type used for an unarchived, uncompressed model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfigRaw = "application/vnd.cncf.model.weight.config.v1.raw"
 
-	// MediaTypeModelConfig specifies the media type for configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfig specifies the media type for configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfig = "application/vnd.cncf.model.weight.config.v1.tar"
 
-	// MediaTypeModelConfigGzip specifies the media type for gzipped configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfigGzip specifies the media type for gzipped configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfigGzip = "application/vnd.cncf.model.weight.config.v1.tar+gzip"
 
-	// MediaTypeModelConfigZstd specifies the media type for zstd compressed configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfigZstd specifies the media type for zstd compressed configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfigZstd = "application/vnd.cncf.model.weight.config.v1.tar+zstd"
 
 	// MediaTypeModelDocRaw is the media type used for an unarchived, uncompressed model documentation, including documentation files like `README.md`, `LICENSE`, etc.


### PR DESCRIPTION
## Description

- Fix typo "incercept" → "intercept" in `schema/example_test.go`
- Fix godoc comments in `specs-go/v1/mediatype.go` where three weight config constants (`MediaTypeModelWeightConfig`, `MediaTypeModelWeightConfigGzip`, `MediaTypeModelWeightConfigZstd`) had comments incorrectly referencing `MediaTypeModelConfig*` instead of `MediaTypeModelWeightConfig*`

## Motivation and Context

The godoc comment names did not match their corresponding constants, which could mislead contributors reading the documentation. The typo is a straightforward spelling error.
