### PR TITLE
add TransformerConfig with typed attention and MLP variants

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -131,6 +131,49 @@ The following terms are used in this section:
 
     Quantization technique applied to the model, such as "awq", or "gptq".
 
+  - **transformerConfig** _object_, OPTIONAL
+
+    Transformer-specific architectural parameters. Should only be populated when `architecture` is `"transformer"`.
+
+    - **attentionType** _string_, OPTIONAL
+
+      The attention mechanism variant. Supported values:
+
+      | Value | Description |
+      |-------|-------------|
+      | `"mha"` | Multi-Head Attention — standard attention with one KV head per query head |
+      | `"gqa"` | Grouped-Query Attention — fewer KV heads than query heads, reducing KV cache size (e.g. LLaMA 3, Mistral) |
+      | `"mla"` | Multi-Latent Attention — low-rank KV compression for minimal KV cache (e.g. DeepSeek-V2) |
+
+    - **mlpType** _string_, OPTIONAL
+
+      The feed-forward / MLP layer variant. Supported values:
+
+      | Value | Description |
+      |-------|-------------|
+      | `"dense"` | Standard dense feed-forward layer |
+      | `"moe"` | Mixture-of-Experts — tokens are routed to a subset of expert FFN layers (e.g. Mixtral, DeepSeek-V3) |
+
+    - **numLayers** _integer_, OPTIONAL
+
+      Total number of transformer layers (blocks).
+
+    - **numAttentionHeads** _integer_, OPTIONAL
+
+      Number of query attention heads.
+
+    - **numKVHeads** _integer_, OPTIONAL
+
+      Number of key/value heads. For GQA this is smaller than `numAttentionHeads`. Omitting this field or setting it equal to `numAttentionHeads` implies standard MHA.
+
+    - **hiddenSize** _integer_, OPTIONAL
+
+      The model's hidden dimension size (`d_model`).
+
+    - **intermediateSize** _integer_, OPTIONAL
+
+      The inner dimension of the feed-forward layer.
+
   - **capabilities** _object_, OPTIONAL
 
     Special capabilities that the model supports, such as reasoning, toolusage, etc.
@@ -208,6 +251,15 @@ Here is an example model artifact configuration JSON document:
     "paramSize": "8b",
     "precision": "float16",
     "quantization": "gptq",
+    "transformerConfig": {
+      "attentionType": "gqa",
+      "mlpType": "dense",
+      "numLayers": 32,
+      "numAttentionHeads": 32,
+      "numKVHeads": 8,
+      "hiddenSize": 4096,
+      "intermediateSize": 14336
+    },
     "capabilities": {
       "inputTypes": [
         "text"

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -39,8 +39,45 @@
           "quantization": {
             "type": "string"
           },
+          "transformerConfig": {
+            "$ref": "#/$defs/TransformerConfig"
+          },
           "capabilities": {
             "$ref": "#/$defs/ModelCapabilities"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TransformerConfig": {
+        "type": "object",
+        "properties": {
+          "attentionType": {
+            "type": "string",
+            "enum": ["mha", "gqa", "mla"]
+          },
+          "mlpType": {
+            "type": "string",
+            "enum": ["dense", "moe"]
+          },
+          "numLayers": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "numAttentionHeads": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "numKVHeads": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "hiddenSize": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "intermediateSize": {
+            "type": "integer",
+            "minimum": 1
           }
         },
         "additionalProperties": false

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -40,6 +40,10 @@ type ModelConfig struct {
 	// The model quantization, such as awq, gptq, etc
 	Quantization string `json:"quantization,omitempty"`
 
+	// TransformerConfig contains Transformer-specific architectural parameters.
+	// Populated only when Architecture is "transformer".
+	TransformerConfig *TransformerConfig `json:"transformerConfig,omitempty"`
+
 	// Special capabilities that the model supports
 	Capabilities *ModelCapabilities `json:"capabilities,omitempty"`
 }
@@ -93,6 +97,57 @@ type ModelDescriptor struct {
 
 	// The human-readable description of the software packaged in the model
 	Description string `json:"description,omitempty"`
+}
+
+// AttentionType defines the attention mechanism used in a Transformer model.
+type AttentionType string
+
+const (
+	// MultiHeadAttention is the standard multi-head attention (MHA) from "Attention Is All You Need".
+	MultiHeadAttention AttentionType = "mha"
+
+	// GroupedQueryAttention uses fewer KV heads than query heads, reducing KV cache size (e.g. LLaMA 3, Mistral).
+	GroupedQueryAttention AttentionType = "gqa"
+
+	// MultiLatentAttention uses low-rank key-value compression to minimize KV cache (e.g. DeepSeek-V2).
+	MultiLatentAttention AttentionType = "mla"
+)
+
+// MLPType defines the feed-forward / MLP layer variant used in a Transformer model.
+type MLPType string
+
+const (
+	// DenseFF is a standard dense feed-forward layer.
+	DenseFF MLPType = "dense"
+
+	// MixtureOfExperts routes tokens to a subset of expert FFN layers (e.g. Mixtral, DeepSeek-V3).
+	MixtureOfExperts MLPType = "moe"
+)
+
+// TransformerConfig captures the key architectural parameters of a Transformer model.
+// It is only populated when ModelConfig.Architecture is "transformer".
+type TransformerConfig struct {
+	// AttentionType is the attention mechanism variant (mha, gqa, mla).
+	AttentionType AttentionType `json:"attentionType,omitempty"`
+
+	// MLPType is the feed-forward layer variant (dense, moe).
+	MLPType MLPType `json:"mlpType,omitempty"`
+
+	// NumLayers is the total number of transformer layers (blocks).
+	NumLayers *int `json:"numLayers,omitempty"`
+
+	// NumAttentionHeads is the number of query attention heads.
+	NumAttentionHeads *int `json:"numAttentionHeads,omitempty"`
+
+	// NumKVHeads is the number of key/value heads. For GQA this is less than NumAttentionHeads.
+	// Omitted or equal to NumAttentionHeads implies full MHA.
+	NumKVHeads *int `json:"numKVHeads,omitempty"`
+
+	// HiddenSize is the model's hidden dimension (d_model).
+	HiddenSize *int `json:"hiddenSize,omitempty"`
+
+	// IntermediateSize is the inner dimension of the feed-forward layer.
+	IntermediateSize *int `json:"intermediateSize,omitempty"`
 }
 
 // Modality defines the input and output types of the model


### PR DESCRIPTION
  feat: add TransformerConfig with typed attention and MLP variants

  Introduce TransformerConfig struct to ModelConfig with typed constants
  for attention type (mha, gqa, mla) and MLP type (dense, moe), along
  with key hyperparameter fields (numLayers, numAttentionHeads, numKVHeads,
  hiddenSize, intermediateSize). Update config-schema.json and docs/config.md
  accordingly.

  This lays the groundwork for the unified Transformer specification,
  enabling inference engines to auto-detect model variants without
  per-model adaptation.