### PR TITLE
 Fix mismatched doc comments on exported weight config constants

### DIFF
--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -40,13 +40,13 @@ const (
 	// MediaTypeModelWeightConfigRaw is the media type used for an unarchived, uncompressed model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfigRaw = "application/vnd.cncf.model.weight.config.v1.raw"
 
-	// MediaTypeModelConfig specifies the media type for configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfig specifies the media type for configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfig = "application/vnd.cncf.model.weight.config.v1.tar"
 
-	// MediaTypeModelConfigGzip specifies the media type for gzipped configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfigGzip specifies the media type for gzipped configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfigGzip = "application/vnd.cncf.model.weight.config.v1.tar+gzip"
 
-	// MediaTypeModelConfigZstd specifies the media type for zstd compressed configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
+	// MediaTypeModelWeightConfigZstd specifies the media type for zstd compressed configuration of the model weights, including files like `tokenizer.json`, `config.json`, etc.
 	MediaTypeModelWeightConfigZstd = "application/vnd.cncf.model.weight.config.v1.tar+zstd"
 
 	// MediaTypeModelDocRaw is the media type used for an unarchived, uncompressed model documentation, including documentation files like `README.md`, `LICENSE`, etc.


### PR DESCRIPTION
## Description

Fix Go doc comments for three exported constants in `specs-go/v1/mediatype.go` where the comment name did not match the actual constant name:

- `MediaTypeModelWeightConfig` — comment incorrectly started with `MediaTypeModelConfig`
- `MediaTypeModelWeightConfigGzip` — comment incorrectly started with `MediaTypeModelConfigGzip`
- `MediaTypeModelWeightConfigZstd` — comment incorrectly started with `MediaTypeModelConfigZstd`

All three comments were missing the `Weight` segment in the identifier name, causing them to violate Go's convention that doc comments on exported identifiers should start with the identifier's name.

## Related Issue

No existing issue. This was identified by reviewing the doc comments in the `mediatype.go` file. 

## Motivation and Context

Go doc comments on exported identifiers should start with the identifier name (per Go conventions and `go vet`/`revive` best practices). These mismatched comments could cause confusion for contributors and consumers of the package, especially when relying on generated documentation (e.g., `pkg.go.dev`), where the comment text would reference a non-existent identifier.
